### PR TITLE
make .arclint valid and reflect D9029's capabilities

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -22,7 +22,8 @@
     },
     "text" : {
       "type" : "text",
-      "include" : "(\\.txt$)"
+      "include" : "(\\.txt$)",
+      "text.max-line-length" : 81
     },
     "ruby" : {
       "type" : "ruby",

--- a/.arclint
+++ b/.arclint
@@ -1,5 +1,4 @@
 {
-  "debug" : true,
   "linters" : {
     "pep8" : {
       "type" : "pep8",


### PR DESCRIPTION
I don't know what `"debug": true` should accomplish, but it causes this error for me:

```
Exception
Got unexpected parameters: debug
```

So I removed it.
